### PR TITLE
gems atualizadas pro Rails 3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,31 +1,30 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 3.2.13'
-gem 'mysql2', '~> 0.3.11'
-
+gem "rails", "~> 3.2.14"
+gem 'mysql2', '~> 0.3.13'
 
 # Gems used only for assets and not required
 # in production environments by default.
 group :assets do
-  gem 'sass-rails', '~> 3.2.3'
+  gem "sass-rails", "~> 3.2.6"
   gem 'therubyracer', '~> 0.11.4'
-  gem 'bootstrap-sass', '~> 2.3.1.0'
-  gem 'coffee-rails', '~> 3.2.1'
-  gem 'uglifier', '>= 1.0.3'
+  gem "bootstrap-sass", "~> 2.3.2.1"
+  gem "coffee-rails", "~> 3.2.2"
+  gem "uglifier", "~> 2.1.2"
 end
 
 group :development, :test do
-	gem 'pry'
-	gem 'rspec-rails'
-	gem 'guard-rspec'
-	gem 'factory_girl_rails'
+	gem "pry", "~> 0.9.12.2"
+	gem "rspec-rails", "~> 2.14.0"
+  gem "guard-rspec", "~> 3.0.2"
+  gem "factory_girl_rails", "~> 3.6.0"
 end
 
 group :test do
-  gem 'rb-inotify'
+  gem "rb-inotify", "~> 0.9.0"
 end
 
-gem 'jquery-rails', '~> 2.2.1'
+gem "jquery-rails", "~> 3.0.4"
 gem 'simple_form', '~> 2.1.0'
 gem 'client_side_validations', '~> 3.2.5'
 gem 'client_side_validations-simple_form', '~> 2.1.0'


### PR DESCRIPTION
Ae Germano atualizei as gem pra última versão que ainda usam o rails 3.2.x
Desse jeito a gente não preocupa com falha de segurança, etc.
